### PR TITLE
feature: [BE] 보안 강화: 카카오 로그인 응답에서 providerId 정보 제거 #26

### DIFF
--- a/backend/src/main/java/ssap/ssap/dto/Account.java
+++ b/backend/src/main/java/ssap/ssap/dto/Account.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class Account {
-    private String providerId;
     private String userName;
     private String userEmail;
 }

--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -49,7 +49,6 @@ public class KakaoOAuthService implements OAuthService {
         loginResponse.setLoginSuccess(true);
 
         Account account = new Account();
-        account.setProviderId(userInfo.getProviderId());
         account.setUserName(userInfo.getUserName());
         account.setUserEmail(userInfo.getUserEmail());
         loginResponse.setAccount(account);


### PR DESCRIPTION
Closes #26

## 요약
사용자 정보 응답 구조에서 providerId 필드 제거

## 변경 내용 
사용자 정보 응답 구조에서 providerId 필드 제거

## 이슈 번호 또는 링크
#26 