### PR TITLE
feature: [BE] 카카오 로그인 기능 구현 #6

### DIFF
--- a/backend/src/main/java/ssap/ssap/domain/User.java
+++ b/backend/src/main/java/ssap/ssap/domain/User.java
@@ -1,0 +1,25 @@
+package ssap.ssap.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    @Column(name = "provider_id", unique = true)
+    private String providerId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+}

--- a/backend/src/main/java/ssap/ssap/exception/CustomDuplicateKeyException.java
+++ b/backend/src/main/java/ssap/ssap/exception/CustomDuplicateKeyException.java
@@ -1,0 +1,9 @@
+package ssap.ssap.exception;
+
+public class CustomDuplicateKeyException extends RuntimeException {
+
+    public CustomDuplicateKeyException(String message) {
+        super(message);
+    }
+}
+

--- a/backend/src/main/java/ssap/ssap/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/ssap/ssap/exception/GlobalExceptionHandler.java
@@ -17,4 +17,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handleException(Exception ex) {
         return new ResponseEntity<>("An unexpected error occurred: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
     }
+
+    @ExceptionHandler(CustomDuplicateKeyException.class)
+    public ResponseEntity<?> handleCustomDuplicateKeyException(CustomDuplicateKeyException ex) {
+        String errorMessage = "해당 제공자 ID는 이미 사용 중입니다: " + ex.getMessage();
+        return new ResponseEntity<>(errorMessage, HttpStatus.CONFLICT);
+    }
+
 }

--- a/backend/src/main/java/ssap/ssap/repository/UserRepository.java
+++ b/backend/src/main/java/ssap/ssap/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package ssap.ssap.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ssap.ssap.domain.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByProviderId(String providerId);
+}


### PR DESCRIPTION
Closes #6

## 요약
- 카카오 로그인 시 사용자 정보(providerId, email, name) DB 저장 로직 추가

## 변경 내용 
- 카카오 로그인 시 사용자 정보(providerId, email, name) DB 저장 로직 추가

## 이슈 번호 또는 링크
#6