### PR TITLE
fix: [BE] 카카오 로그아웃 기능 구현 #39

### DIFF
--- a/backend/src/main/java/ssap/ssap/controller/OAuthController.java
+++ b/backend/src/main/java/ssap/ssap/controller/OAuthController.java
@@ -69,9 +69,21 @@ public class OAuthController {
             return ResponseEntity.ok(newAccessToken);
         } else {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("액세스 토큰 갱신에 실패했습니다.");
-
-
-
         }
+    }
+    @Operation(summary = "OAuth 로그아웃", description = "사용자를 OAuth 세션에서 로그아웃합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OAuth 로그아웃 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 또는 토큰 만료"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PostMapping("/{provider}/logout")
+    public ResponseEntity<?> logout(
+            @Parameter(name = "provider", description = "OAuth 제공자", required = true) @PathVariable String provider,
+            @Parameter(description = "로그아웃할 사용자의 액세스 토큰", required = true) @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String accessToken = authorizationHeader.substring("Bearer ".length());
+        oauthService.logout(provider, accessToken);
+        return ResponseEntity.ok(provider + " 로그아웃 성공");
     }
 }

--- a/backend/src/main/java/ssap/ssap/exception/CustomServiceException.java
+++ b/backend/src/main/java/ssap/ssap/exception/CustomServiceException.java
@@ -1,0 +1,7 @@
+package ssap.ssap.exception;
+
+public class CustomServiceException extends RuntimeException {
+    public CustomServiceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -20,6 +20,7 @@ import ssap.ssap.dto.LoginResponseDto;
 import ssap.ssap.dto.OAuthDTO;
 import org.json.JSONObject;
 import ssap.ssap.exception.CustomDuplicateKeyException;
+import ssap.ssap.exception.CustomServiceException;
 import ssap.ssap.repository.UserRepository;
 
 import java.util.Optional;
@@ -47,6 +48,9 @@ public class KakaoOAuthService implements OAuthService {
 
     @Value("${kakao.token-info-uri:https://kapi.kakao.com/v1/user/access_token_info}")
     private String kakaoTokenInfoUri;
+
+    @Value("${kakao.api.base-url:https://kapi.kakao.com}")
+    private String kakaoApiBaseUrl;
 
 
     @Autowired
@@ -204,5 +208,23 @@ public class KakaoOAuthService implements OAuthService {
         }
     }
 
+    @Override
+    public void logout(String provider, String accessToken) {
+        if (!"kakao".equalsIgnoreCase(provider)) {
+            throw new IllegalArgumentException("지원하지 않는 OAuth 제공자입니다: " + provider);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<?> httpEntity = new HttpEntity<>(headers);
+
+        String logoutUri = kakaoApiBaseUrl + "/v1/user/logout";
+
+        try {
+            restTemplate.exchange(logoutUri, HttpMethod.POST, httpEntity, String.class);
+        } catch (HttpClientErrorException e) {
+            throw new CustomServiceException("카카오 로그아웃 중 오류가 발생했습니다.", e);
+        }
+    }
 
 }

--- a/backend/src/main/java/ssap/ssap/service/OAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/OAuthService.java
@@ -9,4 +9,6 @@ public interface OAuthService {
     boolean isAccessTokenValid(String accessToken);
 
     String refreshAccessToken(String refreshToken);
+
+    void logout(String provider, String accessToken);
 }


### PR DESCRIPTION
Closes #39

## 요약
- 카카오 로그아웃 API 연동하여 로그아웃 기능 구현

## 변경 내용 
카카오 로그아웃 API 연동하여 로그아웃 기능 추가

## 이슈 번호 또는 링크
#39 