### PR TITLE
feature: 카카오 로그인 시 사용자 정보 추가 수집 및 DB 저장 #78

### DIFF
--- a/backend/src/main/java/ssap/ssap/domain/User.java
+++ b/backend/src/main/java/ssap/ssap/domain/User.java
@@ -22,4 +22,13 @@ public class User {
     @Column(name = "email", nullable = false)
     private String email;
 
+    @Column(name = "gender", nullable = true)
+    private String gender;
+
+    @Column(name = "birthdate", nullable = true)
+    private String birthdate;
+
+    @Column(name = "ageRange", nullable = true)
+    private String ageRange;
+
 }

--- a/backend/src/main/java/ssap/ssap/dto/Account.java
+++ b/backend/src/main/java/ssap/ssap/dto/Account.java
@@ -8,4 +8,7 @@ import lombok.Setter;
 public class Account {
     private String userName;
     private String userEmail;
+    private String gender;
+    private String birthdate;
+    private String ageRange;
 }

--- a/backend/src/main/java/ssap/ssap/dto/OAuthDTO.java
+++ b/backend/src/main/java/ssap/ssap/dto/OAuthDTO.java
@@ -12,4 +12,7 @@ public class OAuthDTO {
     private String userEmail;
     private String accessToken;
     private String refreshToken;
+    private String gender;
+    private String birthdate;
+    private String ageRange;
 }

--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -77,6 +77,9 @@ public class KakaoOAuthService implements OAuthService {
                 Account account = new Account();
                 account.setUserName(user.getName());
                 account.setUserEmail(user.getEmail());
+                account.setGender(user.getGender());
+                account.setBirthdate(user.getBirthdate());
+                account.setAgeRange(user.getAgeRange());
                 loginResponse.setAccount(account);
                 loginResponse.setLoginSuccess(true);
 
@@ -115,6 +118,10 @@ public class KakaoOAuthService implements OAuthService {
         user.setProviderId(oauthInfo.getProviderId());
         user.setName(oauthInfo.getUserName());
         user.setEmail(oauthInfo.getUserEmail());
+        user.setGender(oauthInfo.getGender());
+        user.setBirthdate(oauthInfo.getBirthdate());
+        user.setAgeRange(oauthInfo.getAgeRange());
+
 
         return user;
     }
@@ -136,10 +143,6 @@ public class KakaoOAuthService implements OAuthService {
                 return existingUserOpt.get();
             } else {
                 User newUser = mapOAuthDTOToUserEntity(oauthInfo);
-
-                newUser.setProviderId(oauthInfo.getProviderId());
-                newUser.setName(oauthInfo.getUserName());
-                newUser.setEmail(oauthInfo.getUserEmail());
 
                 return userRepository.save(newUser);
             }
@@ -194,12 +197,19 @@ public class KakaoOAuthService implements OAuthService {
         JSONObject jsonObj = new JSONObject(response.getBody());
         JSONObject account = jsonObj.getJSONObject("kakao_account");
 
+        String gender = account.optString("gender");
+        String birthdate = account.optString("birthday");
+        String ageRange = account.optString("age_range");
+
         OAuthDTO oauthInfo = new OAuthDTO();
         oauthInfo.setProvider("kakao");
         oauthInfo.setProviderId(String.valueOf(jsonObj.getLong("id")));
         oauthInfo.setUserName(account.optJSONObject("profile").optString("nickname"));
         oauthInfo.setUserEmail(account.optString("email"));
         oauthInfo.setAccessToken(accessToken);
+        oauthInfo.setGender(gender);
+        oauthInfo.setBirthdate(birthdate);
+        oauthInfo.setAgeRange(ageRange);
 
         return oauthInfo;
     }


### PR DESCRIPTION
## 요약
- 성별 DB 저장 및 FE 응답 데이터로 반환 하도록 수정
- 생년월일 DB 저장 및 FE 응답 데이터로 반환 하도록 수정
- 연령대 DB 저장 및 FE 응답 데이터로 반환 하도록 수정

## 변경 내용 
- 성별 DB 저장 및 FE 응답 데이터로 반환 하도록 수정
- 생년월일 DB 저장 및 FE 응답 데이터로 반환 하도록 수정
- 연령대 DB 저장 및 FE 응답 데이터로 반환 하도록 수정

## 이슈 번호 또는 링크
#78 