### PR TITLE
feature: 카카오 로그인 시 사용자 정보 추가 수집 및 DB 저장 #78

### DIFF
--- a/backend/src/main/java/ssap/ssap/domain/User.java
+++ b/backend/src/main/java/ssap/ssap/domain/User.java
@@ -31,4 +31,7 @@ public class User {
     @Column(name = "ageRange", nullable = true)
     private String ageRange;
 
+    @Column(name = "profileImageUrl", nullable = true)
+    private String profileImageUrl;
+
 }

--- a/backend/src/main/java/ssap/ssap/dto/OAuthDTO.java
+++ b/backend/src/main/java/ssap/ssap/dto/OAuthDTO.java
@@ -15,4 +15,5 @@ public class OAuthDTO {
     private String gender;
     private String birthdate;
     private String ageRange;
+    private String profileImageUrl;
 }

--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -121,6 +121,7 @@ public class KakaoOAuthService implements OAuthService {
         user.setGender(oauthInfo.getGender());
         user.setBirthdate(oauthInfo.getBirthdate());
         user.setAgeRange(oauthInfo.getAgeRange());
+        user.setProfileImageUrl(oauthInfo.getProfileImageUrl());
 
 
         return user;
@@ -200,6 +201,8 @@ public class KakaoOAuthService implements OAuthService {
         String gender = account.optString("gender");
         String birthdate = account.optString("birthday");
         String ageRange = account.optString("age_range");
+        String profileImageUrl = account.optJSONObject("profile").optString("thumbnail_image_url");
+
 
         OAuthDTO oauthInfo = new OAuthDTO();
         oauthInfo.setProvider("kakao");
@@ -210,6 +213,7 @@ public class KakaoOAuthService implements OAuthService {
         oauthInfo.setGender(gender);
         oauthInfo.setBirthdate(birthdate);
         oauthInfo.setAgeRange(ageRange);
+        oauthInfo.setProfileImageUrl(profileImageUrl);
 
         return oauthInfo;
     }


### PR DESCRIPTION
Closes #78

## 요약
- 카카오 프로필 사진 url DB 저장 및 FE 응답 데이터로 반환 하도록 수정

## 변경 내용 
- 카카오 프로필 사진 url DB 저장 및 FE 응답 데이터로 반환 하도록 수정

## 이슈 번호 또는 링크
#78 