### PR TITLE
fix: 카카오 로그인 사용자 프로필 이미지 url 반환 안되는 문제 #83

### DIFF
--- a/backend/src/main/java/ssap/ssap/dto/Account.java
+++ b/backend/src/main/java/ssap/ssap/dto/Account.java
@@ -11,4 +11,5 @@ public class Account {
     private String gender;
     private String birthdate;
     private String ageRange;
+    private String profileImageUrl;
 }

--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -80,6 +80,7 @@ public class KakaoOAuthService implements OAuthService {
                 account.setGender(user.getGender());
                 account.setBirthdate(user.getBirthdate());
                 account.setAgeRange(user.getAgeRange());
+                account.setProfileImageUrl(user.getProfileImageUrl());
                 loginResponse.setAccount(account);
                 loginResponse.setLoginSuccess(true);
 


### PR DESCRIPTION
Closes #83

## 요약
- Account 클래스에 사용자 프로필 이미지 url 변수 추가 및 서비스 로직에서 account 인스턴스에 url값 할당하도록 추가

## 변경 내용 
- Account 클래스에 사용자 프로필 이미지 url 변수 추가 및 서비스 로직에서 account 인스턴스에 url값 할당하도록 추가

## 이슈 번호 또는 링크
#83 