### PR TITLE
feature: 카카오 사용자 정보 DB에 저장 시 데이터값 가공하여 저장하도록 수정 #85

### DIFF
--- a/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
+++ b/backend/src/main/java/ssap/ssap/service/KakaoOAuthService.java
@@ -119,9 +119,28 @@ public class KakaoOAuthService implements OAuthService {
         user.setProviderId(oauthInfo.getProviderId());
         user.setName(oauthInfo.getUserName());
         user.setEmail(oauthInfo.getUserEmail());
-        user.setGender(oauthInfo.getGender());
+
+        String gender = oauthInfo.getGender();
+        if ("male".equals(gender)) {
+            user.setGender("남자");
+        } else if ("female".equals(gender)) {
+            user.setGender("여자");
+        } else {
+            user.setGender("기타"); // gender 값이 없거나 다른 경우
+        }
+
         user.setBirthdate(oauthInfo.getBirthdate());
-        user.setAgeRange(oauthInfo.getAgeRange());
+
+        String ageRange = oauthInfo.getAgeRange();
+        if (ageRange != null && ageRange.matches("\\d+~\\d+")) {
+            // 숫자~숫자 형식에 맞는 경우
+            String ageGroup = ageRange.split("~")[0] + "대";
+            user.setAgeRange(ageGroup);
+        } else {
+            // 형식에 맞지 않는 경우나 비어 있는 경우
+            user.setAgeRange("정보 없음"); // 또는 다른 적절한 기본값 사용
+        }
+
         user.setProfileImageUrl(oauthInfo.getProfileImageUrl());
 
 


### PR DESCRIPTION
Closes #85

## 요약
- ageRange값: "30~39"로 저장되는 것을 "30대"로 저장하도록 수정
- gender값: "male"인 경우 "남자", "female"인 경우 "여자", "값이 없는 경우 "정보 없음"으로 저장되도록 수정

## 변경 내용 
- ageRange값: "30~39"로 저장되는 것을 "30대"로 저장하도록 수정
- gender값: "male"인 경우 "남자", "female"인 경우 "여자", "값이 없는 경우 "정보 없음"으로 저장되도록 수정

## 이슈 번호 또는 링크
#85 