### PR TITLE
fix: S3Config.java 파일에 PROXY_HOST 설정 수정 #98

### DIFF
--- a/backend/src/main/java/ssap/ssap/config/S3Config.java
+++ b/backend/src/main/java/ssap/ssap/config/S3Config.java
@@ -24,8 +24,7 @@ public class S3Config {
     @Value("${AWS_SECRET_ACCESS_KEY:defaultSecretKey}")
     private String secretKey;
 
-//    @Value("${PROXY_HOST:defaultProxyHost}")
-    @Value("${PROXY_HOST:}")
+    @Value("${PROXY_HOST:defaultProxyHost}")
     private String proxyHost;
 
     @Value("${PROXY_PORT:8080}")


### PR DESCRIPTION
Closes #98

## 요약
- S3Config.java 파일에 PROXY_HOST 설정시 로컬에서 작업 후, default값 설정 하는 코드로 변경해두지 않아, 배포 했을 때 동작하지 않는 문제 수정

## 변경 내용 
- S3Config.java 파일에 PROXY_HOST 설정 수정(로컬에서 테스트를 위해 주석 처리 했던 부분 주석 해제)

## 이슈 번호 또는 링크
#98 