### PR TITLE
HomePage에 MainHeader, Main컴포넌트 추가 및 요청하기 라우터 처리 등

### DIFF
--- a/frontend/src/components/@common/Button/Button.tsx
+++ b/frontend/src/components/@common/Button/Button.tsx
@@ -90,13 +90,17 @@ const ButtonColors = {
 };
 
 const ButtonOuter = styled.div<Omit<ButtonProps, "text">>`
+  display: flex;
+  justify-content: center;
   width: 100%;
+
   ${({ fixed }) =>
     fixed &&
     css`
       position: fixed;
-      /* top: 0;  */
-      /* left: 0;     */
+      left: 0;
+      /* top: 0 */
+      bottom: 20px;
     `}
 `;
 

--- a/frontend/src/components/@common/Header/GnbHeader/GnbHeader.tsx
+++ b/frontend/src/components/@common/Header/GnbHeader/GnbHeader.tsx
@@ -52,11 +52,7 @@ export const GnbHeader = (gnbHeaderProps: GnbHeaderProps) => {
       )}
       <Title>{title}</Title>
       <IconWrapper>
-        <img
-          src={headerImage.close}
-          alt="닫기 버튼"
-          onClick={handleClose}
-        />
+        <img src={headerImage.close} alt="닫기 버튼" onClick={handleClose} />
       </IconWrapper>
     </GnbHeaderWrapper>
   );
@@ -78,6 +74,8 @@ const IconWrapper = styled.div`
   align-items: center;
   width: 24px;
   height: 24px;
+  cursor: pointer;
+
   img {
     width: 100%;
   }

--- a/frontend/src/components/@common/Header/Menu/UserProfile.tsx
+++ b/frontend/src/components/@common/Header/Menu/UserProfile.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import styled from "styled-components";
 import defaultProfileImg from "../../../../assets/images/ssap_icon.svg";
 import { user } from "../../../../mocks/userData";
-import { LoginHandler } from "../../../../pages/Login/LoginHandler";
+import { LogoutHandler } from "../../../../apis/Logout";
 
+// 로그아웃 처리
 const handleLogout = () => {
-  LoginHandler();
+  LogoutHandler();
 };
 
 function UserProfile() {

--- a/frontend/src/components/ErrandList/ErrandItem.tsx
+++ b/frontend/src/components/ErrandList/ErrandItem.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import styled, { css } from "styled-components";
-import defaultProfileImg from "../../assets/images/ssap_logo_B.svg";
+import defaultProfileImg from "../../assets/images/ssap_icon.svg";
 import { LikedButton } from "./LikedButton";
 
 export interface ErrandItemProps {

--- a/frontend/src/components/ErrandList/Errands.tsx
+++ b/frontend/src/components/ErrandList/Errands.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ErrandItem, ErrandItemProps } from "./ErrandItem";
 import styled from "styled-components";
-import { ErrandItems } from "../../mocks/errands";
+import { errandsData } from "../../mocks/errandsData";
 import { useQuery } from "react-query";
 import { getErrands } from "../../apis/errand";
 

--- a/frontend/src/mocks/errandsData.ts
+++ b/frontend/src/mocks/errandsData.ts
@@ -1,0 +1,24 @@
+export const errandsData = {
+  content: [
+    {
+      taskId: 11,
+      jibunAddress: "서울특별시 동작구 상도동 511",
+      thumbnailUrl: "",
+      title: "카공 같이할 사람",
+      fee: 1000,
+      auctionStartTime: "2023-11-31 14:00",
+      auctionEndTime: "53분 후 마감",
+      isLiked: false,
+    },
+    {
+      taskId: 12,
+      jibunAddress: "서울특별시 동작구 상도동 511",
+      thumbnailUrl: "",
+      title: "카공 같이할 사람",
+      fee: 1000,
+      auctionStartTime: "2023-11-31 14:00",
+      auctionEndTime: "53분 후 마감",
+      isLiked: true,
+    },
+  ],
+};

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -1,12 +1,34 @@
 import React from "react";
-import Home from "../../components/Home/Home";
+import Main from "../../components/Main/Main";
+import { MainHeader } from "../../components/@common/Header/MainHeader";
+import styled from "styled-components";
+import { useNavigate } from "react-router-dom";
+import { Button } from "../../components/@common/Button/Button";
 
 function HomePage() {
+  const navigate = useNavigate();
+
+  // 요청서 작성하기로 이동
+  const handleRequestClick = () => {
+    navigate("/errand/request");
+  };
+
   return (
-    <div>
-      <Home />
-    </div>
+    <HomeWrapper>
+      <MainHeader />
+      <Main />
+      <Button
+        fixed
+        text="✋ 요청하기"
+        size="medium"
+        onClick={handleRequestClick}
+      />
+    </HomeWrapper>
   );
 }
+const HomeWrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
 
 export default HomePage;

--- a/frontend/src/pages/Login/LoginPage.tsx
+++ b/frontend/src/pages/Login/LoginPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { KAKAO_AUTH_URL } from "../../apis/OAuth";
-import kakaoImage from "../../assets/Kakao.png";
+import kakaoImage from "../../assets/images/Kakao.png";
 import { Link } from "react-router-dom";
 
 export default function LoginPage() {


### PR DESCRIPTION
## 요약
HomePage에 MainHeader, Main컴포넌트 추가 및 요청하기 라우터 처리하였습니다.

## 변경 내용 
- HomePage에 MainHeader, Main컴포넌트 추가 및 요청하기 라우터 처리
- 로그아웃 버튼 클릭 시 LogoutHandler 함수 호출
- 심부름 내역 TEST 데이터 추가
- 이미지 파일 images 폴더로 옮기면서 import 수정
- 닫기 버튼 alt 수정 및 마우스 커서 포인트되도록 css 수정
- 썸네일 기본 이미지 수정

## 이슈 번호 또는 링크
