### PR TITLE
refactor : 심부름 상세 정보 조회 taskId를 통해 Auction 엔티티를 찾는 로직 수정

### DIFF
--- a/backend/src/main/java/ssap/ssap/repository/AuctionRepository.java
+++ b/backend/src/main/java/ssap/ssap/repository/AuctionRepository.java
@@ -3,7 +3,11 @@ package ssap.ssap.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import ssap.ssap.domain.Auction;
+import ssap.ssap.domain.Task;
+
+import java.util.Optional;
 
 @Repository
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
+    Optional<Auction> findByTaskId(Long taskId);
 }

--- a/backend/src/main/java/ssap/ssap/service/ErrandDetailedService.java
+++ b/backend/src/main/java/ssap/ssap/service/ErrandDetailedService.java
@@ -38,8 +38,8 @@ public class ErrandDetailedService {
         User requester = userRepository.findById(task.getUser().getUserId())
                 .orElseThrow(() -> new EntityNotFoundException("userId 을 찾을 수 없습니다.: " + task.getUser().getUserId()));
 
-        // User 객체를 찾으며, 찾을 수 없다면 예외를 발생
-        Auction auction = auctionRepository.findById(task.getId())
+        // Auction 객체를 찾으며, 찾을 수 없다면 예외를 발생
+        Auction auction = auctionRepository.findByTaskId(task.getId())
                 .orElseThrow(() -> new EntityNotFoundException("auctionId 을 찾을 수 없습니다.: " + task.getId()));
 
         // 조회된 정보를 바탕으로 Map을 생성하여 반환


### PR DESCRIPTION
## 요약

심부름 상세 정보 조회 taskId를 통해 Auction 엔티티를 찾는 로직 수정

## 변경 내용 

AuctionRepository
Optional<Auction> findByTaskId(Long taskId); 추가

ErrandDetailedService
findByTaskId(task.getId())로 수정
주석 수정

## 이슈 번호 또는 링크

#160