### PR TITLE
fix: 심부름 상세 페이지 조회 시, 경매 등록이 안된 심부름인 경우, 경매ID를 못찾는 문제 #177

### DIFF
--- a/backend/src/main/java/ssap/ssap/service/ErrandDetailedService.java
+++ b/backend/src/main/java/ssap/ssap/service/ErrandDetailedService.java
@@ -12,6 +12,7 @@ import ssap.ssap.repository.UserRepository;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 public class ErrandDetailedService {
@@ -38,9 +39,8 @@ public class ErrandDetailedService {
         User requester = userRepository.findById(task.getUser().getUserId())
                 .orElseThrow(() -> new EntityNotFoundException("userId 을 찾을 수 없습니다.: " + task.getUser().getUserId()));
 
-        // Auction 객체를 찾으며, 찾을 수 없다면 예외를 발생
-        Auction auction = auctionRepository.findByTaskId(task.getId())
-                .orElseThrow(() -> new EntityNotFoundException("auctionId 을 찾을 수 없습니다.: " + task.getId()));
+        // Auction 객체를 찾으며, 존재하지 않는 경우에 대한 처리를 추가
+        Optional<Auction> auction = auctionRepository.findByTaskId(task.getId());
 
         // 조회된 정보를 바탕으로 Map을 생성하여 반환
         Map<String, Object> details = new HashMap<>();
@@ -62,7 +62,8 @@ public class ErrandDetailedService {
         details.put("ageRange", task.getUser().getAgeRange());
         details.put("gender", task.getUser().getGender());
         details.put("profileImageUrl", task.getUser().getProfileImageUrl());
-        details.put("auctionId",auction.getId());
+        // Auction 객체가 존재하는 경우 해당 ID를 저장, 존재하지 않는 경우 null 저장
+        details.put("auctionId", auction.map(Auction::getId).orElse(null));
 
         return details;
     }


### PR DESCRIPTION
Closes #177

## 요약
- 경매 정보가 없는 경우 auctionId에 null 반환하도록 수정

## 변경 내용 
- 경매 정보가 없는 경우 auctionId에 null 반환하도록 수정

## 이슈 번호 또는 링크
#177 