### PR TITLE
fix: 심부름 요청서 작성 시, 경매 일정 등록을 했음에도, tasks테이블에 auction_id값이 null로 보이는 문제

### DIFF
--- a/backend/src/main/java/ssap/ssap/service/TaskService.java
+++ b/backend/src/main/java/ssap/ssap/service/TaskService.java
@@ -104,8 +104,6 @@ public class TaskService {
         task.setCategory(category);
         task.setDetailedItem(detailedItem);
 
-        taskRepository.save(task); // task 저장
-
         if (task.getAuctionStatus()) {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             LocalDateTime auctionStartTime = LocalDateTime.parse(createForm.getAuctionStartTime(), formatter);
@@ -115,8 +113,12 @@ public class TaskService {
             auction.setTask(task);
             auction.setStartTime(auctionStartTime);
             auction.setEndTime(auctionEndTime);
+
+            task.setAuction(auction); // auction_id 외래키 매핑
             auctionRepository.save(auction);
         }
+
+        taskRepository.save(task);
 
         return task;
     }


### PR DESCRIPTION
Closes #192

## 요약
심부름 요청서 작성 시, 경매 일정 등록을 했음에도, tasks테이블에 auction_id값이 null로 보이는 문제 

## 변경 내용 
- Task 엔티티의 auction_id 외래키 매핑 오류 수정

## 이슈 번호 또는 링크
#192 