### PR TITLE
[FE] hotfix auction ID 를 받아오지 못하는 현상 수정

### DIFF
--- a/frontend/src/apis/auctionDetail.ts
+++ b/frontend/src/apis/auctionDetail.ts
@@ -4,7 +4,7 @@ export const getAuctionDetail = async (auctionId, accessToken) => {
   try {
     const response = await api.get(`/api/bids/${auctionId}/latest-bid`, {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        // Authorization: `Bearer ${accessToken}`,
       },
     });
     return response.data;

--- a/frontend/src/apis/category.ts
+++ b/frontend/src/apis/category.ts
@@ -6,7 +6,7 @@ export const getCategories = async () => {
   try {
     const response = await api.get(`/api/categories`, {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        // Authorization: `Bearer ${accessToken}`,
       },
     });
     console.log("category.ts 안 response.data:", response.data);
@@ -23,7 +23,7 @@ export const getSubCategories = async (categoryId) => {
   try {
     const response = await api.get(`/api/categories/${categoryId}/items`, {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        // Authorization: `Bearer ${accessToken}`,
       },
     });
     return response.data;

--- a/frontend/src/apis/currentBid.ts
+++ b/frontend/src/apis/currentBid.ts
@@ -20,7 +20,7 @@ export const GetCurrentBid = async (
       },
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          // Authorization: `Bearer ${accessToken}`,
         },
       },
     );

--- a/frontend/src/apis/errand.ts
+++ b/frontend/src/apis/errand.ts
@@ -15,7 +15,7 @@ export const ErrandRequestPost = async (errandFormData: ErrandFormData) => {
   try {
     const response = await api.post(`${APP_URL}/api/request`, formData, {
       headers: {
-        Authorization: `Bearer ${accessToken}`, // TODO 로컬 테스트용
+        // Authorization: `Bearer ${accessToken}`, // TODO 로컬 테스트용
         "Content-Type": "multipart/form-data",
       },
     });
@@ -32,10 +32,10 @@ export const getErrands = async (location: string) => {
   console.log("api 호출전 주소 확인:", location);
   try {
     const response = await api.get(
-      `${APP_URL}/api/errands?address=${location}&page=0&size=100`,
+      `/api/errands?address=${location}&page=0&size=100`,
       {
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          // Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",
         },
       },

--- a/frontend/src/apis/errandCategory.ts
+++ b/frontend/src/apis/errandCategory.ts
@@ -5,7 +5,7 @@ const fetchErrandCategory = async (categoryId) => {
   try {
     const response = await api.get(`/api/errands/category/${categoryId}`, {
       headers: {
-        Authorization: `Bearer ${accessToken}`,
+        // Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
     });

--- a/frontend/src/apis/errandDetail.ts
+++ b/frontend/src/apis/errandDetail.ts
@@ -3,7 +3,7 @@ import api from "./api";
 const getErrandDetails = async (taskId, accessToken) => {
   const response = await api.get(`/api/errands/${taskId}`, {
     headers: {
-      Authorization: `Bearer ${accessToken}`,
+      // Authorization: `Bearer ${accessToken}`,
       "Content-Type": "application/json",
     },
   });

--- a/frontend/src/components/ErrandDetail/Title.tsx
+++ b/frontend/src/components/ErrandDetail/Title.tsx
@@ -5,7 +5,7 @@ const Title = ({ data }) => {
   const [requestData, setRequestData] = useState(mockData.request);
   const [response, setResponseData] = useState(mockData.response);
   const auctionEndTime =
-    data.auctionEndTime || "경매로 설정되지 않은 심부름입니다.";
+    `${data.auctionEndTime} 경매마감` || "경매로 설정되지 않은 심부름입니다.";
 
   //TODO 편의점 배달 부분 detailItem api 수정되면 고치기
   return (
@@ -19,7 +19,7 @@ const Title = ({ data }) => {
       <Layout>
         <TitleLayout>
           <ErrandTitle>{data.title}</ErrandTitle>
-          <Deadline>{auctionEndTime} 경매 마감</Deadline>
+          <Deadline>{auctionEndTime}</Deadline>
         </TitleLayout>
       </Layout>
     </Wrapper>

--- a/frontend/src/components/bottomSheet/Content.tsx
+++ b/frontend/src/components/bottomSheet/Content.tsx
@@ -32,8 +32,6 @@ const Content = ({
 
   const errandFeeLocale = Number(data.fee).toLocaleString();
 
-  const notify = () => toast("입찰에 성공하였습니다");
-  const warn = () => toast("입찰 금액이 현재 입찰가보다 커야 합니다. ");
   //TODO 입찰에 실패했을 경우 추후에 추가
 
   const validateInputChange = (event) => {


### PR DESCRIPTION
## 요약
hotfix auction ID 를 받아오지 못하는 현상 수정

## 변경 내용 
- 코드를 수정하였으나, 기존에는 동작되었던 코드였기에, 서버쪽에서의 수정을 요청드리고 클라쪽의 코드는 기존 코드를 유지하게 되었습니다.
- 필요없는 코드는 제거하고, 헤더에 토큰을 넣어서 보내는 로직은 이미 api.ts에서 하고 있기에 다른 api를 호출하는 함수에서의 해당로직은 전부 주석처리 하였습니다. 
- api 호출 시 헤더가 겹치면 에러가 발생한다네요.
- 경매 일정이 등록되지 않은 심부름 문구를 올바르게 수정하였습니다.

## 이슈 번호 또는 링크
