### PR TITLE
feature: 특정 경매 입찰 정보 조회 시, 한번도 입찰이 이루어지지 않은 경우, 금액을 심부름 초기 가격을 반환하도록 수정

### DIFF
--- a/backend/src/main/java/ssap/ssap/service/BidService.java
+++ b/backend/src/main/java/ssap/ssap/service/BidService.java
@@ -77,17 +77,31 @@ public class BidService {
     }
 
     public BidResponseDto findLatestBidByAuctionId(Long auctionId) {
+        log.debug("경매 ID에 따른 최신 입찰 찾기: 값 = {}, 타입 = {}", auctionId, auctionId.getClass().getSimpleName());
         Bid latestBid = bidRepository.findTopByAuctionIdOrderByTimeDesc(auctionId);
-        if (latestBid == null) {
-            return null;
-        }
 
-        return new BidResponseDto(
-                latestBid.getId(),
-                latestBid.getAmount(),
-                latestBid.getUser().getEmail(),
-                latestBid.getUser().getName(),
-                latestBid.getTime()
-        );
+        if (latestBid != null) {
+            return new BidResponseDto(
+                    latestBid.getId(),
+                    latestBid.getAmount(),
+                    latestBid.getUser().getEmail(),
+                    latestBid.getUser().getName(),
+                    latestBid.getTime()
+            );
+        } else {
+            // latestBid가 null인 경우, 관련 Auction을 찾아서 해당 Task의 fee 값을 리턴
+            Auction auction = auctionRepository.findById(auctionId)
+                    .orElseThrow(() -> new EntityNotFoundException("경매를 찾을 수 없습니다: " + auctionId));
+            Task task = auction.getTask();
+            Integer fee = Integer.valueOf(task.getFee());
+
+            return new BidResponseDto(
+                    null,
+                    fee,
+                    null,
+                    null,
+                    null
+            );
+        }
     }
 }


### PR DESCRIPTION
Closes #196

## 요약
- 특정 경매 입찰 정보 조회 시, 한번도 입찰이 이루어지지 않은 경우 심부름 초기 가격을 반환하도록 수정

## 변경 내용 
- 특정 경매 입찰 정보 조회 시, 한번도 입찰이 이루어지지 않은 경우 심부름 초기 가격을 반환하도록 수정

## 이슈 번호 또는 링크
#196 