### PR TITLE
Hotfix: #204 바텀 시트 유저 플로우에 맞게 ui 및 프로필 등 변경

### DIFF
--- a/frontend/src/components/ErrandDetail/Title.tsx
+++ b/frontend/src/components/ErrandDetail/Title.tsx
@@ -7,7 +7,21 @@ const Title = ({ data }) => {
   const auctionEndTime =
     `${data.auctionEndTime} 경매마감` || "경매로 설정되지 않은 심부름입니다.";
 
+  const currentDate = new Date();
+  const auctionEndTimeString = data.auctionEndTime;
+  const auctionEnd = new Date(auctionEndTimeString);
+  const isAuctionClosed = currentDate > auctionEnd; //경매 종료 여부 확인
+
+  // const dateText = isAuctionClosed ? "경매 마감" : auctionEndTime;
   //TODO 편의점 배달 부분 detailItem api 수정되면 고치기
+
+  if (data.auctionId === null) {
+    ("일반 지원");
+  } else {
+    auctionEndTime;
+  }
+  const dateText = data.auctionId === null ? "일반 지원" : auctionEndTime;
+
   return (
     <Wrapper>
       <BtnLayout>
@@ -19,7 +33,7 @@ const Title = ({ data }) => {
       <Layout>
         <TitleLayout>
           <ErrandTitle>{data.title}</ErrandTitle>
-          <Deadline>{auctionEndTime}</Deadline>
+          <Deadline>{dateText}</Deadline>
         </TitleLayout>
       </Layout>
     </Wrapper>

--- a/frontend/src/components/ErrandDetail/UserProfile.tsx
+++ b/frontend/src/components/ErrandDetail/UserProfile.tsx
@@ -1,19 +1,25 @@
 import React from "react";
+import { useRecoilValue } from "recoil";
 import styled from "styled-components";
+import { authInfoState } from "../../recoil/atoms/userInfo";
 
 const UserProfile = ({ data }) => {
+  const user = useRecoilValue(authInfoState);
   return (
     <OutsideLayout>
       <InsideLayout>
         <UserThumbnail>
-          <img src={data.profileImageUrl} />
+          <img
+            src={user.profileImageUrl}
+            alt={`${user.userName}의 프로필 이미지`}
+          />
         </UserThumbnail>
         <UserInfoLayout>
           <UserInfoDetail>
-            <UserNickname>{data.name}</UserNickname>
+            <UserNickname>{user.userName || "이름 없음"}</UserNickname>
             <UserAge>
-              {data.gender}
-              {data.ageRange}
+              {user.gender}
+              {user.ageRange}
             </UserAge>
           </UserInfoDetail>
         </UserInfoLayout>

--- a/frontend/src/components/bottomSheet/Content.tsx
+++ b/frontend/src/components/bottomSheet/Content.tsx
@@ -32,9 +32,19 @@ const Content = ({
   const [currentBid, setCurrentBid] = useState(auctionData.amount); //현재 입찰가
   const [bidAmount, setBidAmount] = useState(""); //유저가 입력한 값
 
+  const currentDate = new Date();
+  const auctionEndTimeString = data.auctionEndTime;
+  const auctionEndTime = new Date(auctionEndTimeString);
+
   const errandFeeLocale = Number(data.fee).toLocaleString();
   const currentBidAmount = Number(auctionData.amount).toLocaleString();
-  //TODO 입찰에 실패했을 경우 추후에 추가
+
+  const isAuctionClosed = currentDate > auctionEndTime; //경매 종료 여부 확인
+
+  // 버튼 텍스트 설정
+  const buttonText = isAuctionClosed
+    ? "이미 경매가 마감되었습니다"
+    : "💓 입찰하기";
 
   console.log("bidAmount", bidAmount);
   console.log("currentBid", currentBid);
@@ -118,9 +128,9 @@ const Content = ({
         <Button
           size="large"
           color="primary"
-          text="💓 입찰하기"
-          // onClick={bidBtnClick}
+          text={buttonText}
           onClick={handleBidClick}
+          disabled={isAuctionClosed}
         />
       </ContentWrapper>
     </FormProvider>

--- a/frontend/src/pages/ErrandDetails/ErrandDetailsPage.tsx
+++ b/frontend/src/pages/ErrandDetails/ErrandDetailsPage.tsx
@@ -21,6 +21,8 @@ import { authInfoState } from "../../recoil/atoms/userInfo";
 import { getAuctionDetail } from "../../apis/auctionDetail";
 import Template from "../../components/Template";
 import styled from "styled-components";
+import ErrorMessage from "../../components/@common/Error/ErrorMessage";
+import { errorToast, successToast } from "../../constants/toast";
 
 const ErrandDetailsPage = () => {
   const [open, setOpen] = useState(false);
@@ -110,7 +112,10 @@ const ErrandDetailsPage = () => {
   console.log("auctionId :", auctionId);
 
   const openBottomSheet = () => {
-    setOpen(true);
+    // setOpen(true);
+    errandData.auctionId === null
+      ? successToast("지원이 완료되었습니다.")
+      : setOpen(true);
   };
 
   const handleBack = () => {


### PR DESCRIPTION
## 요약

바텀 시트 유저 플로우에 맞게 ui 및 프로필 등 변경

## 변경 내용 

- 경매 마감된 게시물엔 버튼 비활성화
- 일반 지원 게시물에 "경매 마감"이 아닌 "일반 지원"으로 출력
- 일반 지원 게시물에서 지원하기 클릭 시 성공 토스트 메세지 출력
- 상세 페이지 하단 유저 프로필을 리코일에서 가져와서 프로필 메세지와 나이를 출력

## 이슈 번호 또는 링크
#204 